### PR TITLE
Add null check to stringbuilder loop in WriteDAE_Source_map

### DIFF
--- a/ImportExport/Writers/ExternalWriters/DAEWriter.cs
+++ b/ImportExport/Writers/ExternalWriters/DAEWriter.cs
@@ -468,6 +468,10 @@ namespace SM64DSe.ImportExport.Writers.ExternalWriters
                 {
                     sb.Append(Helper.ToString(texCoord.X) + " " + Helper.ToString(texCoord.Y) + " ");
                 }
+                else
+                {
+                    sb.Append(Helper.ToString(0.0f) + " " + Helper.ToString(0.0f) + " ");
+                }
             }
             sb.Remove(sb.Length - 1, 1);// Remove extra space character at end
             writer.WriteString(sb.ToString());

--- a/ImportExport/Writers/ExternalWriters/DAEWriter.cs
+++ b/ImportExport/Writers/ExternalWriters/DAEWriter.cs
@@ -464,7 +464,10 @@ namespace SM64DSe.ImportExport.Writers.ExternalWriters
             StringBuilder sb = new StringBuilder();
             foreach (Vector2 texCoord in texCoordsInBranch)
             {
-                sb.Append(Helper.ToString(texCoord.X) + " " + Helper.ToString(texCoord.Y) + " ");
+                if (texCoord != null)
+                {
+                    sb.Append(Helper.ToString(texCoord.X) + " " + Helper.ToString(texCoord.Y) + " ");
+                }
             }
             sb.Remove(sb.Length - 1, 1);// Remove extra space character at end
             writer.WriteString(sb.ToString());


### PR DESCRIPTION
This method was causing the program to quit during model export from mario64DS during this specific loop, because a null Vector2 was being read, adding this null check makes the program export correctly